### PR TITLE
Remove Kong logo image URL from frontmatter

### DIFF
--- a/docs/API/KongAPI.md
+++ b/docs/API/KongAPI.md
@@ -1,7 +1,6 @@
 ---
 description: Quickly build API-centric applications. Leverage the latest microservice and container design patterns. And tie it all together with the Kong microservice API gateway.
 title: API Gateway (powered by Kong CE)
-image: "https://raw.githubusercontent.com/Kong/docker-official-docs/master/kong/logo.png"
 author: ll911 leo.lou@gov.bc.ca
 ---
 ## API Gateway (powered by Kong CE)


### PR DESCRIPTION
The Kong logo that is referenced in `docs/API/KongAPI.md` points to a third party repository is missing/moved and returns a 404. This 404 error breaks the DevHub build process (see [example](https://github.com/bcgov/devhub-app-web/runs/6086272793?check_suite_focus=true)). Removing this logo will mean it no longer shows up in the Kong topic card in DevHub.

<img width="1840" alt="Current DevHub production instance showing Kong logo on its topic card" src="https://user-images.githubusercontent.com/25143706/164115961-193ce7eb-a2f3-4518-9596-64a967d1fff3.png">
